### PR TITLE
Make logo adapt to dark mode; add source code links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # qujax
 
 <div align="center">
-<a href="https://cqcl.github.io/qujax/"><img src="docs/logo.svg" alt="logo"></img></a>
+<a href="https://cqcl.github.io/qujax/">
+<picture>
+    <source srcset="docs/logo_dark_mode.svg"  media="(prefers-color-scheme: dark)">
+    <img src="docs/logo.svg">
+</picture>
+</a>
 </div>
 
 [![PyPI - Version](https://img.shields.io/pypi/v/qujax)](https://pypi.org/project/qujax/)

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -27,8 +27,10 @@
     background: #85cfcb;
 }
 
-.wy-nav-content {
-    max-width: 1000px;
+@media screen and (min-width: 1000px) {
+    .wy-nav-content {
+        max-width: 1000px;
+    }
 }
 
 html.writer-html4 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
@@ -50,4 +52,8 @@ h1, h2, h3, h4, h5, h6 {
 
 div.toctree-wrapper .caption-text{
     color: #203847;
+}
+
+.rst-content .viewcode-back, .rst-content .viewcode-link {
+    padding-left: 6px;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,17 @@ html_theme_options = {
 
 
 def linkcode_resolve(domain, info):
+    """
+    Called by sphinx's linkcode extension, which adds links directing the user to the
+    source code of the API objects being documented. The `domain` argument specifies which
+    programming language the object belongs to. The `info` argument is a dictionary with
+    information specific to the programming language of the object.
+
+    For Python objects, this dictionary contains a `module` key with the module the object is in
+    and a `fullname` key with the name of the object. This function uses this information to find
+    the source file and range of lines the object is defined in and to generate a link pointing to
+    those lines on GitHub.
+    """
     github_url = f"https://github.com/CQCL/qujax/tree/develop/qujax"
 
     if domain != "py":

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import importlib
+import inspect
+import pathlib
 
 sys.path.insert(0, os.path.abspath(".."))  # pylint: disable=wrong-import-position
 
@@ -22,6 +25,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
+    "sphinx.ext.linkcode",
     "myst_parser",
 ]
 
@@ -62,3 +66,24 @@ html_theme_options = {
     "collapse_navigation": False,
     "prev_next_buttons_location": "None",
 }
+
+
+def linkcode_resolve(domain, info):
+    github_url = f"https://github.com/CQCL/qujax/tree/develop/qujax"
+
+    if domain != "py":
+        return
+
+    module = importlib.import_module(info["module"])
+    obj = getattr(module, info["fullname"])
+
+    try:
+        path = pathlib.Path(inspect.getsourcefile(obj))
+        file_name = path.name
+        lines = inspect.getsourcelines(obj)
+    except TypeError:
+        return
+
+    start_line, end_line = lines[1], lines[1] + len(lines[0]) - 1
+
+    return f"{github_url}/{file_name}#L{start_line}-L{end_line}"

--- a/docs/logo_dark_mode.svg
+++ b/docs/logo_dark_mode.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="148.7834"
+   height="149.73567"
+   viewBox="0 0 39.365602 39.617558"
+   version="1.1"
+   id="svg17698"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   sodipodi:docname="logo_dark_mode.svg"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview17700"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="121.79914"
+     inkscape:cy="-2.3864854"
+     inkscape:window-width="1850"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" /><defs
+     id="defs17695" /><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-21.637854,-21.400273)"><path
+       id="rect234-5-6-0-6-2-8-0-5-8-3-5"
+       style="fill:none;stroke:#85cfcb;stroke-width:7.141;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:1"
+       d="M 25.208354,41.296794 25.2088,28.09905 28.337002,24.970849 h 22.570962"
+       sodipodi:nodetypes="cccc" /><g
+       id="g1324"
+       style="stroke:#1e5c71;stroke-width:7.141;stroke-dasharray:none;stroke-opacity:1"
+       transform="translate(1.8876761,1.5062664)"><path
+         style="fill:none;stroke:#1e5c71;stroke-width:7.141;stroke-dasharray:none;stroke-opacity:1"
+         d="M 40.21429,42.513342 56.783433,56.808128"
+         id="path1157-5-9-3-6-6-7-2-9-9-1-0"
+         sodipodi:nodetypes="cc" /><path
+         id="rect842-3-2-9-0-1-9-3-2-7-9-3"
+         style="fill:none;stroke:#1e5c71;stroke-width:7.141;stroke-dasharray:none;stroke-opacity:1"
+         d="m 52.576016,19.894011 2.9e-5,25.613917 v 0 l -7.727356,7.841925 v 0 H 23.320678 V 39.790528"
+         sodipodi:nodetypes="ccccccc" /></g></g></svg>


### PR DESCRIPTION
- Make logo adapt to dark mode (it currently partly blends into the dark background)
- Add source code links to the API in the documentation. These links take the user directly to the range of lines where the function is defined in the source file in the GitHub repository.