### PR TITLE
Avoid floating point error in `jnp.log2` with x64 enabled

### DIFF
--- a/qujax/__init__.py
+++ b/qujax/__init__.py
@@ -2,7 +2,6 @@
 Simulating quantum circuits with JAX
 """
 
-
 from qujax.version import __version__
 
 from qujax import gates

--- a/qujax/densitytensor_observable.py
+++ b/qujax/densitytensor_observable.py
@@ -188,7 +188,5 @@ def densitytensor_to_measured_densitytensor(
     unnorm_densitytensor = _kraus_single(
         densitytensor, qubit_inds_projector, qubit_inds
     )
-    norm_const = jnp.trace(
-        unnorm_densitytensor.reshape(2**n_qubits, 2**n_qubits)
-    ).real
+    norm_const = jnp.trace(unnorm_densitytensor.reshape(2**n_qubits, 2**n_qubits)).real
     return unnorm_densitytensor / norm_const

--- a/qujax/statetensor_observable.py
+++ b/qujax/statetensor_observable.py
@@ -50,13 +50,14 @@ def get_hermitian_tensor(hermitian_seq: Sequence[Union[str, jax.Array]]) -> jax.
 
     single_arrs = [paulis[h] if isinstance(h, str) else h for h in hermitian_seq]
     single_arrs = [
-        h_arr.reshape((2,) * int(jnp.log2(h_arr.size))) for h_arr in single_arrs
+        h_arr.reshape((2,) * int(jnp.rint(jnp.log2(h_arr.size))))
+        for h_arr in single_arrs
     ]
 
     full_mat = single_arrs[0]
     for single_matrix in single_arrs[1:]:
         full_mat = jnp.kron(full_mat, single_matrix)
-    full_mat = full_mat.reshape((2,) * int(jnp.log2(full_mat.size)))
+    full_mat = full_mat.reshape((2,) * int(jnp.rint(jnp.log2(full_mat.size))))
     return full_mat
 
 

--- a/qujax/typing.py
+++ b/qujax/typing.py
@@ -10,25 +10,21 @@ from jax.typing import ArrayLike
 class PureParameterizedCircuit(Protocol):
     def __call__(
         self, params: ArrayLike, statetensor_in: Optional[jax.Array] = None
-    ) -> jax.Array:
-        ...
+    ) -> jax.Array: ...
 
 
 class PureUnparameterizedCircuit(Protocol):
-    def __call__(self, statetensor_in: Optional[jax.Array] = None) -> jax.Array:
-        ...
+    def __call__(self, statetensor_in: Optional[jax.Array] = None) -> jax.Array: ...
 
 
 class MixedParameterizedCircuit(Protocol):
     def __call__(
         self, params: ArrayLike, densitytensor_in: Optional[jax.Array] = None
-    ) -> jax.Array:
-        ...
+    ) -> jax.Array: ...
 
 
 class MixedUnparameterizedCircuit(Protocol):
-    def __call__(self, densitytensor_in: Optional[jax.Array] = None) -> jax.Array:
-        ...
+    def __call__(self, densitytensor_in: Optional[jax.Array] = None) -> jax.Array: ...
 
 
 GateArgs = TypeVarTuple("GateArgs")

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -235,7 +235,9 @@ def test_sampling():
     target_pmf = jnp.array([0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0])
     target_pmf /= target_pmf.sum()
 
-    target_st = jnp.sqrt(target_pmf).reshape((2,) * int(jnp.log2(target_pmf.size)))
+    target_st = jnp.sqrt(target_pmf).reshape(
+        (2,) * int(jnp.rint(jnp.log2(target_pmf.size)))
+    )
 
     n_samps = 7
 
@@ -244,5 +246,8 @@ def test_sampling():
     assert all(target_pmf[sample_ints] > 0)
 
     sample_bitstrings = qujax.sample_bitstrings(random.PRNGKey(0), target_st, n_samps)
-    assert sample_bitstrings.shape == (n_samps, int(jnp.log2(target_pmf.size)))
+    assert sample_bitstrings.shape == (
+        n_samps,
+        int(jnp.rint(jnp.log2(target_pmf.size))),
+    )
     assert all(qujax.bitstrings_to_integers(sample_bitstrings) == sample_ints)


### PR DESCRIPTION
Use of `jnp.log2` can cause floating point errors on x64:
```python
>>> import jax
>>> jax.config.update("jax_enable_x64", True)
>>> import jax.numpy as jnp
>>> arr = jnp.zeros((2,) * 6, dtype=jnp.float64)
>>> jnp.log2(arr.size)
Array(6., dtype=float64)
>>> int(jnp.log2(arr.size))
5
```