### PR TITLE
Run `black` formatter

### DIFF
--- a/qujax/__init__.py
+++ b/qujax/__init__.py
@@ -2,7 +2,6 @@
 Simulating quantum circuits with JAX
 """
 
-
 from qujax.version import __version__
 
 from qujax import gates

--- a/qujax/densitytensor_observable.py
+++ b/qujax/densitytensor_observable.py
@@ -188,7 +188,5 @@ def densitytensor_to_measured_densitytensor(
     unnorm_densitytensor = _kraus_single(
         densitytensor, qubit_inds_projector, qubit_inds
     )
-    norm_const = jnp.trace(
-        unnorm_densitytensor.reshape(2**n_qubits, 2**n_qubits)
-    ).real
+    norm_const = jnp.trace(unnorm_densitytensor.reshape(2**n_qubits, 2**n_qubits)).real
     return unnorm_densitytensor / norm_const

--- a/qujax/typing.py
+++ b/qujax/typing.py
@@ -10,25 +10,21 @@ from jax.typing import ArrayLike
 class PureParameterizedCircuit(Protocol):
     def __call__(
         self, params: ArrayLike, statetensor_in: Optional[jax.Array] = None
-    ) -> jax.Array:
-        ...
+    ) -> jax.Array: ...
 
 
 class PureUnparameterizedCircuit(Protocol):
-    def __call__(self, statetensor_in: Optional[jax.Array] = None) -> jax.Array:
-        ...
+    def __call__(self, statetensor_in: Optional[jax.Array] = None) -> jax.Array: ...
 
 
 class MixedParameterizedCircuit(Protocol):
     def __call__(
         self, params: ArrayLike, densitytensor_in: Optional[jax.Array] = None
-    ) -> jax.Array:
-        ...
+    ) -> jax.Array: ...
 
 
 class MixedUnparameterizedCircuit(Protocol):
-    def __call__(self, densitytensor_in: Optional[jax.Array] = None) -> jax.Array:
-        ...
+    def __call__(self, densitytensor_in: Optional[jax.Array] = None) -> jax.Array: ...
 
 
 GateArgs = TypeVarTuple("GateArgs")


### PR DESCRIPTION
The lint check is failing on PR #123 due to a update of the black formatter. This formats the files failing the check so that PR can eventually be merged.